### PR TITLE
Fs2 kafka 3.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,18 +70,19 @@ lazy val root =
       libraryDependencies ++= {
         val circe     = "io.circe"
         val fd4s      = "com.github.fd4s"
-        val fs2KafkaV = "2.5.0"
+        val fs2KafkaV = "3.0.0"
+
         Seq(
           fd4s                     %% "fs2-kafka"                    % fs2KafkaV,
           fd4s                     %% "fs2-kafka-vulcan"             % fs2KafkaV,
           "com.github.andyglow"    %% "scala-jsonschema"             % "0.7.9",
           circe                    %% "circe-jackson212"             % "0.14.0",
-          circe                    %% "circe-generic"                % "0.14.3",
+          circe                    %% "circe-generic"                % "0.14.5",
           "org.scala-lang.modules" %% "scala-collection-compat"      % "2.8.1",
-          "org.typelevel"          %% "munit-cats-effect-3"          % "1.0.7"  % Test,
+          "org.typelevel"          %% "munit-cats-effect-3"          % "1.0.7"   % Test,
           "com.dimafeng"           %% "testcontainers-scala-munit"   % "0.40.11" % Test,
-          "ch.qos.logback"          % "logback-classic"              % "1.4.4" % Test,
-          "io.confluent"            % "kafka-json-schema-serializer" % "7.1.1"
+          "ch.qos.logback"          % "logback-classic"              % "1.4.4"   % Test,
+          "io.confluent"            % "kafka-json-schema-serializer" % "7.3.3"
         )
       }
     )

--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ lazy val root =
           circe                    %% "circe-generic"                % "0.14.5",
           "org.scala-lang.modules" %% "scala-collection-compat"      % "2.8.1",
           "org.typelevel"          %% "munit-cats-effect-3"          % "1.0.7"   % Test,
-          "com.dimafeng"           %% "testcontainers-scala-munit"   % "0.40.11" % Test,
+          "com.dimafeng"           %% "testcontainers-scala-munit"   % "0.40.14" % Test,
           "ch.qos.logback"          % "logback-classic"              % "1.4.4"   % Test,
           "io.confluent"            % "kafka-json-schema-serializer" % "7.3.3"
         )

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,15 +2,14 @@ version: '2.1'
 
 services:
   zoo1:
-    image: zookeeper:3.4.9
+    image: confluentinc/cp-zookeeper:6.2.0
     restart: unless-stopped
     hostname: zoo1
     ports:
       - "2181:2181"
     environment:
-      ZOO_MY_ID: 1
-      ZOO_PORT: 2181
-      ZOO_SERVERS: server.1=zoo1:2888:3888
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
 
   kafka1:
     image: confluentinc/cp-kafka:6.2.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.7.3
+sbt.version = 1.8.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.3")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")

--- a/src/main/scala/io/kaizensolutions/jsonschema/JsonSchemaDeserializer.scala
+++ b/src/main/scala/io/kaizensolutions/jsonschema/JsonSchemaDeserializer.scala
@@ -16,29 +16,29 @@ import java.nio.ByteBuffer
 import scala.reflect.ClassTag
 
 // See AbstractKafkaJsonSchemaDeserializer
-object JsonSchemaDeserializer   {
+object JsonSchemaDeserializer {
   def forValue[F[_]: Sync, A: Decoder](
     settings: JsonSchemaDeserializerSettings,
     client: SchemaRegistryClient
   )(implicit jsonSchema: json.Schema[A], tag: ClassTag[A]): F[ValueDeserializer[F, A]] =
     toJsonSchema(jsonSchema, settings.jsonSchemaId)
-      .flatMap( schema => forValue(settings, client, schema))
+      .flatMap(schema => forValue(settings, client, schema))
 
-  def forValue[F[_] : Sync, A: Decoder](
+  def forValue[F[_]: Sync, A: Decoder](
     settings: JsonSchemaDeserializerSettings,
     client: SchemaRegistryClient,
     schema: JsonSchema
   ): F[ValueDeserializer[F, A]] =
-    Ref.of[F, Set[Int]](Set.empty[Int])
-      .map { cache =>
-        val objectMapper = Jackson.newObjectMapper().configure(
+    Ref.of[F, Set[Int]](Set.empty[Int]).map { cache =>
+      val objectMapper = Jackson
+        .newObjectMapper()
+        .configure(
           DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
           settings.failOnUnknownKeys
         )
 
-        new JsonSchemaDeserializer[F, A](settings, schema, objectMapper, cache, client)
-          .jsonSchemaDeserializer
-      }
+      new JsonSchemaDeserializer[F, A](settings, schema, objectMapper, cache, client).jsonSchemaDeserializer
+    }
 }
 private class JsonSchemaDeserializer[F[_]: Sync, A](
   settings: JsonSchemaDeserializerSettings,
@@ -53,11 +53,11 @@ private class JsonSchemaDeserializer[F[_]: Sync, A](
   def jsonSchemaDeserializer: Deserializer[F, A] =
     Deserializer.instance { (_, _, bytes) =>
       Sync[F].delay {
-        val buffer             = getByteBuffer(bytes)
-        val id                 = buffer.getInt()
-        val serverSchema       = client.getSchemaById(id).asInstanceOf[JsonSchema]
-        val bufferLength       = buffer.limit() - 1 - IdSize
-        val start              = buffer.position() + buffer.arrayOffset()
+        val buffer       = getByteBuffer(bytes)
+        val id           = buffer.getInt()
+        val serverSchema = client.getSchemaById(id).asInstanceOf[JsonSchema]
+        val bufferLength = buffer.limit() - 1 - IdSize
+        val start        = buffer.position() + buffer.arrayOffset()
         val jsonNode: JsonNode =
           objectMapper.readTree(new ByteArrayInputStream(buffer.array, start, bufferLength))
 
@@ -78,8 +78,8 @@ private class JsonSchemaDeserializer[F[_]: Sync, A](
 
         check.as(jacksonToCirce(jsonNode))
       }
-      .map(decoder.decodeJson)
-      .rethrow
+        .map(decoder.decodeJson)
+        .rethrow
     }
 
   private def getByteBuffer(payload: Array[Byte]): ByteBuffer = {
@@ -92,7 +92,7 @@ private class JsonSchemaDeserializer[F[_]: Sync, A](
   private def checkSchemaCompatibility(serverSubjectId: Int, serverSchema: JsonSchema): F[Unit] = {
     val checkSchemaUpdateCache =
       Sync[F].delay {
-      val incompatibilities = clientSchema.isBackwardCompatible(serverSchema)
+        val incompatibilities = clientSchema.isBackwardCompatible(serverSchema)
         if (!incompatibilities.isEmpty)
           throw new IOException(
             s"Incompatible consumer schema with server schema: ${incompatibilities.toArray.mkString(", ")}"

--- a/src/main/scala/io/kaizensolutions/jsonschema/JsonSchemaDeserializer.scala
+++ b/src/main/scala/io/kaizensolutions/jsonschema/JsonSchemaDeserializer.scala
@@ -3,7 +3,7 @@ package io.kaizensolutions.jsonschema
 import cats.effect.{Ref, Sync}
 import cats.syntax.all.*
 import com.fasterxml.jackson.databind.{DeserializationFeature, JsonNode, ObjectMapper}
-import fs2.kafka.{Deserializer, ValueDeserializer}
+import fs2.kafka.{Deserializer, KeyDeserializer, ValueDeserializer}
 import io.circe.Decoder
 import io.circe.jackson.jacksonToCirce
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
@@ -22,7 +22,7 @@ object JsonSchemaDeserializer {
     client: SchemaRegistryClient
   )(implicit jsonSchema: json.Schema[A], tag: ClassTag[A]): F[ValueDeserializer[F, A]] =
     toJsonSchema(jsonSchema, settings.jsonSchemaId)
-      .flatMap(schema => forValue(settings, client, schema))
+      .flatMap(forValue(settings, client, _))
 
   def forValue[F[_]: Sync, A: Decoder](
     settings: JsonSchemaDeserializerSettings,
@@ -39,6 +39,30 @@ object JsonSchemaDeserializer {
 
       new JsonSchemaDeserializer[F, A](settings, schema, objectMapper, cache, client).jsonSchemaDeserializer
     }
+
+  def forKey[F[_]: Sync, A: Decoder](
+    settings: JsonSchemaDeserializerSettings,
+    client: SchemaRegistryClient
+  )(implicit jsonSchema: json.Schema[A], tag: ClassTag[A]): F[KeyDeserializer[F, A]] =
+    toJsonSchema(jsonSchema, settings.jsonSchemaId)
+      .flatMap(forKey(settings, client, _))
+
+  def forKey[F[_]: Sync, A: Decoder](
+    settings: JsonSchemaDeserializerSettings,
+    client: SchemaRegistryClient,
+    schema: JsonSchema
+  ): F[KeyDeserializer[F, A]] =
+    Ref.of[F, Set[Int]](Set.empty[Int]).map { cache =>
+      val objectMapper = Jackson
+        .newObjectMapper()
+        .configure(
+          DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+          settings.failOnUnknownKeys
+        )
+
+      new JsonSchemaDeserializer[F, A](settings, schema, objectMapper, cache, client).jsonSchemaDeserializer
+    }
+    
 }
 private class JsonSchemaDeserializer[F[_]: Sync, A](
   settings: JsonSchemaDeserializerSettings,

--- a/src/main/scala/io/kaizensolutions/jsonschema/JsonSchemaDeserializerSettings.scala
+++ b/src/main/scala/io/kaizensolutions/jsonschema/JsonSchemaDeserializerSettings.scala
@@ -5,13 +5,20 @@ object JsonSchemaDeserializerSettings {
 }
 
 /**
- * Settings that describe how to interact with Confluent's Schema Registry when deserializing data
+ * Settings that describe how to interact with Confluent's Schema Registry when
+ * deserializing data
  *
- * @param validatePayloadAgainstServerSchema will validate the payload against the schema on the server
- * @param validatePayloadAgainstClientSchema will validate the payload against the schema derived from the datatype you specify
- * @param validateClientSchemaAgainstServer  will validate the schema you specify against the server's schema
- * @param failOnUnknownKeys                  will specify failure when unknown JSON keys are encountered
- * @param jsonSchemaId                       is used to override the schema ID of the data that is being consumed
+ * @param validatePayloadAgainstServerSchema
+ *   will validate the payload against the schema on the server
+ * @param validatePayloadAgainstClientSchema
+ *   will validate the payload against the schema derived from the datatype you
+ *   specify
+ * @param validateClientSchemaAgainstServer
+ *   will validate the schema you specify against the server's schema
+ * @param failOnUnknownKeys
+ *   will specify failure when unknown JSON keys are encountered
+ * @param jsonSchemaId
+ *   is used to override the schema ID of the data that is being consumed
  */
 final case class JsonSchemaDeserializerSettings(
   validatePayloadAgainstServerSchema: Boolean = false,

--- a/src/main/scala/io/kaizensolutions/jsonschema/JsonSchemaSerializer.scala
+++ b/src/main/scala/io/kaizensolutions/jsonschema/JsonSchemaSerializer.scala
@@ -83,11 +83,10 @@ private final class JsonSchemaSerializer[F[_]: Sync, A: Encoder](
   cache: Ref[F, Map[SubjectSchema, ParsedSchema]],
   clientSchema: JsonSchema
 ) {
-  private val MagicByte: Byte = 0x0
-  private val IdSize: Int     = 4
+  val MagicByte: Byte = 0x0
+  val IdSize: Int     = 4
 
-  private val objectMapper = Jackson.newObjectMapper()
-  private val objectWriter = objectMapper.writer()
+  val objectWriter = Jackson.newObjectMapper().writer()
 
   def jsonSchemaSerializer(isKey: Boolean): Serializer[F, A] = {
     val mkSubject = subjectName(isKey) _

--- a/src/main/scala/io/kaizensolutions/jsonschema/JsonSchemaSerializer.scala
+++ b/src/main/scala/io/kaizensolutions/jsonschema/JsonSchemaSerializer.scala
@@ -19,61 +19,62 @@ import scala.reflect.ClassTag
 import scala.jdk.OptionConverters._
 
 /**
- * Look at Confluent's KafkaJsonSchemaSerializer -> AbstractKafkaJsonSchemaSerializer -> AbstractKafkaSchemaSerDe
+ * Look at Confluent's KafkaJsonSchemaSerializer ->
+ * AbstractKafkaJsonSchemaSerializer -> AbstractKafkaSchemaSerDe
  *
  * The real implementation does the following (minus a few details):
  *
- * 1. call configure (provide isKey to figure out the subject name)
- *    - determine whether we automatically register the schema (involves using the subject name and the topic)
- *    - or determine whether we use the latest schema
- *    - determine whether to use strict compatibility
- *    - determine whether to validate the body against the payload and fail if not correct
- * 2. serialization of a message
- *    - extract the JSON Schema of the message (we don't need to do this every time because our Serializers are very specific)
- *    - register the schema (provided configuration) or use the latest schema
- *    - validate message against JSON schema (provided configuration)
- *    - write out message: magic byte ++ subject id ++ payload
+ *   1. call configure (provide isKey to figure out the subject name)
+ *      - determine whether we automatically register the schema (involves using
+ *        the subject name and the topic)
+ *      - or determine whether we use the latest schema
+ *      - determine whether to use strict compatibility
+ *      - determine whether to validate the body against the payload and fail if
+ *        not correct 2. serialization of a message
+ *      - extract the JSON Schema of the message (we don't need to do this every
+ *        time because our Serializers are very specific)
+ *      - register the schema (provided configuration) or use the latest schema
+ *      - validate message against JSON schema (provided configuration)
+ *      - write out message: magic byte ++ subject id ++ payload
  *
- *   see AbstractKafkaJsonSchemaDeserializer for deserialization details
+ * see AbstractKafkaJsonSchemaDeserializer for deserialization details
  */
 object JsonSchemaSerializer {
   final case class SubjectSchema(subject: String, schema: ParsedSchema)
 
   def forKey[F[_]: Sync, A: Encoder](
     settings: JsonSchemaSerializerSettings,
-    client: SchemaRegistryClient,
+    client: SchemaRegistryClient
   )(implicit jsonSchema: json.Schema[A], tag: ClassTag[A]): F[KeySerializer[F, A]] =
     toJsonSchema(jsonSchema, settings.jsonSchemaId)
       .flatMap(forKey[F, A](settings, client, _))
 
-  def forKey[F[_] : Sync, A: Encoder](
+  def forKey[F[_]: Sync, A: Encoder](
     settings: JsonSchemaSerializerSettings,
     client: SchemaRegistryClient,
-    schema: JsonSchema,
+    schema: JsonSchema
   ): F[KeySerializer[F, A]] =
-    Ref.of[F, Map[SubjectSchema, ParsedSchema]](Map.empty)
-      .map { cache =>
-        new JsonSchemaSerializer[F, A](client, settings, cache, schema)
-          .jsonSchemaSerializer(true)
-      }
+    Ref.of[F, Map[SubjectSchema, ParsedSchema]](Map.empty).map { cache =>
+      new JsonSchemaSerializer[F, A](client, settings, cache, schema)
+        .jsonSchemaSerializer(true)
+    }
 
   def forValue[F[_]: Sync, A: Encoder](
     settings: JsonSchemaSerializerSettings,
-    client: SchemaRegistryClient,
+    client: SchemaRegistryClient
   )(implicit jsonSchema: json.Schema[A], tag: ClassTag[A]): F[ValueSerializer[F, A]] =
     toJsonSchema(jsonSchema, settings.jsonSchemaId)
       .flatMap(forValue(settings, client, _))
 
-  def forValue[F[_] : Sync, A: Encoder](
+  def forValue[F[_]: Sync, A: Encoder](
     settings: JsonSchemaSerializerSettings,
     client: SchemaRegistryClient,
-    schema: JsonSchema,
+    schema: JsonSchema
   ): F[ValueSerializer[F, A]] =
-    Ref.of[F, Map[SubjectSchema, ParsedSchema]](Map.empty)
-      .map { cache =>
-        new JsonSchemaSerializer[F, A](client, settings, cache, schema)
-          .jsonSchemaSerializer(false)
-      }
+    Ref.of[F, Map[SubjectSchema, ParsedSchema]](Map.empty).map { cache =>
+      new JsonSchemaSerializer[F, A](client, settings, cache, schema)
+        .jsonSchemaSerializer(false)
+    }
 }
 
 private final class JsonSchemaSerializer[F[_]: Sync, A: Encoder](
@@ -112,16 +113,16 @@ private final class JsonSchemaSerializer[F[_]: Sync, A: Encoder](
         schema <- fSchema
         _      <- validatePayload(schema, jsonPayload)
         id     <- fId
-        bytes  <- Sync[F].delay {
-                    val payloadBytes = objectWriter.writeValueAsBytes(jsonPayload)
-                    val baos         = new ByteArrayOutputStream()
-                    baos.write(MagicByte.toInt)
-                    baos.write(ByteBuffer.allocate(IdSize).putInt(id).array())
-                    baos.write(payloadBytes)
-                    val bytes        = baos.toByteArray
-                    baos.close()
-                    bytes
-                  }
+        bytes <- Sync[F].delay {
+                   val payloadBytes = objectWriter.writeValueAsBytes(jsonPayload)
+                   val baos         = new ByteArrayOutputStream()
+                   baos.write(MagicByte.toInt)
+                   baos.write(ByteBuffer.allocate(IdSize).putInt(id).array())
+                   baos.write(payloadBytes)
+                   val bytes = baos.toByteArray
+                   baos.close()
+                   bytes
+                 }
       } yield bytes
     }
   }
@@ -151,11 +152,11 @@ private final class JsonSchemaSerializer[F[_]: Sync, A: Encoder](
             metadata.getSchema,
             metadata.getReferences
           )
-        }.flatMap { 
+        }.flatMap {
           _.toScala match {
             case Some(x) =>
               Sync[F].pure(x)
-            case None    =>
+            case None =>
               Sync[F].delay(new JsonSchema(metadata.getSchema).validate()) >>
                 // successfully parsed the schema locally means that the client was not properly configured
                 Sync[F].raiseError[ParsedSchema](
@@ -175,21 +176,21 @@ private final class JsonSchemaSerializer[F[_]: Sync, A: Encoder](
   ): F[ParsedSchema] = {
     val ss = SubjectSchema(subject, schema)
     for {
-      map           <- cache.get
-      result         = map.get(ss)
+      map   <- cache.get
+      result = map.get(ss)
       latestVersion <- result match {
                          case Some(cached) => Sync[F].pure(cached)
                          case None         => fetchLatest(subject)
                        }
       // the latest version must be backwards compatible with the current schema
       // this does not test forward compatibility to allow unions
-      compatIssues   = latestVersion.isBackwardCompatible(schema)
-      _             <- Sync[F].whenA(latestCompatStrict && !compatIssues.isEmpty) {
-                         Sync[F].raiseError(
-                           new IOException(s"Incompatible schema: ${compatIssues.toArray.mkString(", ")}")
-                         )
-                      }
-      _             <- Sync[F].whenA(result.isEmpty) { cache.update(_ + (ss -> latestVersion)) }
+      compatIssues = latestVersion.isBackwardCompatible(schema)
+      _ <- Sync[F].whenA(latestCompatStrict && !compatIssues.isEmpty) {
+             Sync[F].raiseError(
+               new IOException(s"Incompatible schema: ${compatIssues.toArray.mkString(", ")}")
+             )
+           }
+      _ <- Sync[F].whenA(result.isEmpty)(cache.update(_ + (ss -> latestVersion)))
     } yield latestVersion
   }
 }

--- a/src/main/scala/io/kaizensolutions/jsonschema/JsonSchemaSerializerSettings.scala
+++ b/src/main/scala/io/kaizensolutions/jsonschema/JsonSchemaSerializerSettings.scala
@@ -5,13 +5,21 @@ object JsonSchemaSerializerSettings {
 }
 
 /**
- * Settings that describe how to interact with Confluent's Schema Registry when serializing data
+ * Settings that describe how to interact with Confluent's Schema Registry when
+ * serializing data
  *
- * @param automaticRegistration dictates whether we try to automatically register the schema we have with the server
- * @param useLatestVersion dictates whether to use the latest schema on the server instead of registering a new one
- * @param validatePayload dictates whether to validate the JSON payload against the schema
- * @param latestCompatStrict dictates whether to use strict compatibility
- * @param jsonSchemaId is used to override the schema ID of the data that is being produced
+ * @param automaticRegistration
+ *   dictates whether we try to automatically register the schema we have with
+ *   the server
+ * @param useLatestVersion
+ *   dictates whether to use the latest schema on the server instead of
+ *   registering a new one
+ * @param validatePayload
+ *   dictates whether to validate the JSON payload against the schema
+ * @param latestCompatStrict
+ *   dictates whether to use strict compatibility
+ * @param jsonSchemaId
+ *   is used to override the schema ID of the data that is being produced
  */
 final case class JsonSchemaSerializerSettings(
   automaticRegistration: Boolean = true,

--- a/src/main/scala/io/kaizensolutions/jsonschema/package.scala
+++ b/src/main/scala/io/kaizensolutions/jsonschema/package.scala
@@ -26,7 +26,9 @@ package object jsonschema {
       )
   }
 
-  def toJsonSchema[F[_]: Sync, T](schema: json.Schema[T], schemaId: Option[String] = None)(implicit tag: ClassTag[T]): F[JsonSchema] = {
+  def toJsonSchema[F[_]: Sync, T](schema: json.Schema[T], schemaId: Option[String] = None)(implicit
+    tag: ClassTag[T]
+  ): F[JsonSchema] = {
     import com.github.andyglow.jsonschema.*
 
     Sync[F].delay {

--- a/src/test/scala/io/kaizensolutions/jsonschema/JsonSchemaSerDesSpec.scala
+++ b/src/test/scala/io/kaizensolutions/jsonschema/JsonSchemaSerDesSpec.scala
@@ -219,8 +219,7 @@ class JsonSchemaSerDesSpec extends CatsEffectSuite with TestContainersForAll {
               )
             }
             .groupWithin(1000, 1.second)
-            .evalMap(_.sequence) // TODO: traverse?
-            .map(x => x.flatMap(_.toIndexedChunk.map(_._1.value))) // TODO: clean up?
+            .evalMap(_.flatTraverse(_.map(_.map(_._1.value))))
             .flatMap(Stream.chunk)
         }
         .compile

--- a/src/test/scala/io/kaizensolutions/jsonschema/JsonSchemaSerDesSpec.scala
+++ b/src/test/scala/io/kaizensolutions/jsonschema/JsonSchemaSerDesSpec.scala
@@ -228,7 +228,7 @@ class JsonSchemaSerDesSpec extends CatsEffectSuite with TestContainersForAll {
     assertion(produceElements)
   }
 
-  def consumeFromKafka[F[_]: Async, A: Decoder: json.Schema: ClassTag](
+  def consumeFromKafka[F[+_]: Async, A: Decoder: json.Schema: ClassTag](
     fClient: F[SchemaRegistryClient],
     settings: JsonSchemaDeserializerSettings,
     groupId: String,


### PR DESCRIPTION
- bumps fs2-kafka dependency to the full 3.0.0 release
- bumps transitive dependencies
- adds scalafmt integration. I assumed that this was accidentally omitted since there was .scalafmt.conf file in the project root.
- dropped overloaded apply method in JsonSchemaSerializer in favor of specialized forKey/forValue methods. This coincides with adoption of KeySerializer/ValueSerializer in fs2-kafka and the intent here is to reduce the amount of casting/coercing/type-casing required by clients.
- renamed JsonSchemaDeserializer.apply to forValue for the same reasons listed above.